### PR TITLE
commentcomponentの変更でイベントを飛ばす #2

### DIFF
--- a/src/app/content.ts
+++ b/src/app/content.ts
@@ -1,19 +1,19 @@
 import "../manifest.json"
 import "../styles/content.scss"
 import { html, render } from "lit-html"
-import DomObserver, { EventType } from "./kintone/dom-observer"
-
-const sayHello = (name: String) => {
-  return html`<h1>Hello, ${name}!!</h1>`
-}
-
-render(sayHello('ofuton'), document.body);
+import DomObserver, {
+  CommentComponentChangedDetail,
+  EventType,
+} from "./kintone/dom-observer"
 
 const domObserver = new DomObserver()
-domObserver.startCommentComponentObserver()
+domObserver.startPostsObserver()
 
-document.addEventListener(EventType.COMMENT_COMPONENT_LOADED, (e) => {
-  const targetEl = (e as CustomEvent).detail.element
-  console.log("comment component loaded", targetEl)
+document.addEventListener(EventType.COMMENT_COMPONENT_CHANGED, (e) => {
+  const customEvent = e as CustomEvent
+  const customEventDetail = customEvent.detail as CommentComponentChangedDetail
+  const targetEl = customEventDetail.element
+  const addedEls = customEventDetail.addedElements
+  console.log("comment component changed", targetEl)
+  console.log("addedEls", addedEls)
 })
-


### PR DESCRIPTION
Usage
```java
// DOMの監視を開始
const domObserver = new DomObserver()
domObserver.startPostsObserver()

// COMMENT_COMPONENT_CHANGEDイベントの発火を検知
document.addEventListener(EventType.COMMENT_COMPONENT_CHANGED, (e) => {
  const customEvent = e as CustomEvent
  const customEventDetail = customEvent.detail as CommentComponentChangedDetail
  // 「変更後のcommentcomponent要素」と「追加されたElementの配列」を返す
  const targetEl = customEventDetail.element
  const addedEls = customEventDetail.addedElements
  console.log("comment component changed", targetEl)
  // => comment component changed <div class=​"ocean-ui-comments-commentcomponent">​…​</div>​
  console.log("addedEls", addedEls)
  // => addedEls [div.ocean-ui-comments-commentbase.ocean-ui-comments-commentbase-featured.ocean-ui-comments-post.oce…]
})

```